### PR TITLE
PoC: FrozenMiniSearch for MCP local docs search (~96% less index RAM)

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -41,7 +41,7 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "fuse.js": "^7.1.0",
-    "minisearch": "^7.2.0",
+    "@yoch/frozenminisearch": "^1.1.0",
     "jq-web": "https://github.com/stainless-api/jq-web/releases/download/v0.8.8/jq-web.tar.gz",
     "pino": "^10.3.1",
     "pino-http": "^11.0.0",

--- a/packages/mcp-server/src/local-docs-search.ts
+++ b/packages/mcp-server/src/local-docs-search.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-import MiniSearch from 'minisearch';
+import FrozenMiniSearch from '@yoch/frozenminisearch';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { getLogger } from './logger';
@@ -1517,18 +1517,17 @@ const INDEX_OPTIONS = {
 };
 
 /**
- * Self-contained local search engine backed by MiniSearch.
+ * Self-contained local search engine backed by FrozenMiniSearch.
  * Method data is embedded at SDK build time; prose documents
  * can be loaded from an optional docs directory at runtime.
  */
 export class LocalDocsSearch {
-  private methodIndex: MiniSearch<MiniSearchDocument>;
-  private proseIndex: MiniSearch<MiniSearchDocument>;
+  private methodDocs: MiniSearchDocument[] = [];
+  private proseDocs: MiniSearchDocument[] = [];
+  private methodIndex!: FrozenMiniSearch<MiniSearchDocument>;
+  private proseIndex!: FrozenMiniSearch<MiniSearchDocument>;
 
-  private constructor() {
-    this.methodIndex = new MiniSearch<MiniSearchDocument>(INDEX_OPTIONS);
-    this.proseIndex = new MiniSearch<MiniSearchDocument>(INDEX_OPTIONS);
-  }
+  private constructor() {}
 
   static async create(opts?: { docsDir?: string }): Promise<LocalDocsSearch> {
     const instance = new LocalDocsSearch();
@@ -1539,7 +1538,13 @@ export class LocalDocsSearch {
     if (opts?.docsDir) {
       await instance.loadDocsDirectory(opts.docsDir);
     }
+    instance.freezeIndexes();
     return instance;
+  }
+
+  private freezeIndexes(): void {
+    this.methodIndex = FrozenMiniSearch.fromDocuments(this.methodDocs, INDEX_OPTIONS);
+    this.proseIndex = FrozenMiniSearch.fromDocuments(this.proseDocs, INDEX_OPTIONS);
   }
 
   search(props: {
@@ -1636,7 +1641,7 @@ export class LocalDocsSearch {
       _original: m as unknown as Record<string, unknown>,
     }));
     if (docs.length > 0) {
-      this.methodIndex.addAll(docs);
+      this.methodDocs.push(...docs);
     }
   }
 
@@ -1686,7 +1691,7 @@ export class LocalDocsSearch {
 
   private indexProse(markdown: string, source: string): void {
     const chunks = chunkMarkdown(markdown);
-    const baseId = this.proseIndex.documentCount;
+    const baseId = this.proseDocs.length;
 
     const docs: MiniSearchDocument[] = chunks.map((chunk, i) => ({
       id: `prose-${baseId + i}`,
@@ -1697,7 +1702,7 @@ export class LocalDocsSearch {
     }));
 
     if (docs.length > 0) {
-      this.proseIndex.addAll(docs);
+      this.proseDocs.push(...docs);
     }
   }
 }


### PR DESCRIPTION
## Summary

Optional PoC: replace `minisearch` with [`@yoch/frozenminisearch`](https://github.com/yoch/frozenminisearch) in `packages/mcp-server/src/local-docs-search.ts`.

`@beeper/desktop-mcp` embeds Beeper Desktop API reference docs and README prose into two `MiniSearch` indexes at startup. After `LocalDocsSearch.create()` completes, the corpus is read-only — only `search()` runs.

## Why this might fit desktop-mcp

- Desktop MCP users often keep the server running alongside the chat client; the docs index stays hot in memory.
- This repo embeds ~33 API methods plus a large prose layer (multi-language READMEs) — dual indexes amplify heap cost.
- Frozen indexes cut retained RAM without changing search semantics (BM25, prefix, fuzzy, boosts).

## Benchmark (beeper-scale corpus, Node v24.16)

Sized to embedded method count (~33) and prose volume (~3,200 chunks), same `INDEX_OPTIONS`:

| | MiniSearch | FrozenMiniSearch |
|---|------------|------------------|
| Dual index heap (retained, post-GC) | 6.96 MB | 0.31 MB (~**96%** less) |
| Top-result ranking (sample queries) | — | matches |

## Code changes

- Build-phase buffering + single `freezeIndexes()` instead of incremental `addAll`.
- Prose ID allocation uses `proseDocs.length` instead of `proseIndex.documentCount`.
- Dependency: `@yoch/frozenminisearch` (Node >= 22.15 on stdio path).

## Stainless disclaimer

`local-docs-search.ts` is OpenAPI-generated. Direct merge may not survive the next Stainless regen — upstream template is the durable fix if this direction is interesting.

No pressure to merge.

## Test plan

- [ ] MCP server package tests
- [ ] Manual docs search on Desktop API queries (e.g. messages, accounts)

Made with [Cursor](https://cursor.com)