### PR TITLE
fix(mcp): grant Deno --allow-net for the execute control socket

### DIFF
--- a/packages/mcp-server/src/code-tool.ts
+++ b/packages/mcp-server/src/code-tool.ts
@@ -122,6 +122,27 @@ export function codeTool({
   return { metadata, tool, handler };
 }
 
+/**
+ * Grants the Deno subprocess net access to its own control socket, and nothing else.
+ *
+ * `@valtown/deno-http-worker` serves its control channel with `Deno.serve({ path })` over a Unix
+ * socket, and since Deno 2.9 binding one needs net access on top of read/write access:
+ *
+ *   NotCapable: Requires net access to "unix:/.../<uuid>-deno-http.sock"
+ *
+ * The library generates that path itself and never exposes it, so recover it from the argv the
+ * library built: it is the only bare (non-flag) argument ending in the socket suffix. Deno's
+ * allowlist matches a Unix socket by full path only — a directory prefix is not accepted — so this
+ * is as tightly as the permission can be scoped.
+ */
+function withControlSocketNetAccess(args: string[]): string[] {
+  const socketPath = args.find((arg) => !arg.startsWith('-') && arg.endsWith('-deno-http.sock'));
+  if (socketPath === undefined) {
+    return args;
+  }
+  return args.map((arg) => (arg.startsWith('--allow-net=') ? `${arg},unix:${socketPath}` : arg));
+}
+
 const localDenoHandler = async ({
   reqContext,
   args,
@@ -146,7 +167,7 @@ const localDenoHandler = async ({
   const packageNodeModulesPath = path.resolve(packageRoot, 'node_modules');
 
   // Check if deno is in PATH
-  const { execSync } = await import('node:child_process');
+  const { execSync, spawn } = await import('node:child_process');
   try {
     execSync('command -v deno', { stdio: 'ignore' });
     denoPath = 'deno';
@@ -195,6 +216,9 @@ const localDenoHandler = async ({
       '--allow-env',
     ],
     printOutput: true,
+    // The worker library appends its own permission flags for the control socket, so patch the
+    // final argv rather than the flags above.
+    spawnFunc: (command, args, options) => spawn(command, withControlSocketNetAccess(args), options),
     spawnOptions: {
       cwd: path.dirname(workerPath),
       // Merge any upstream client envs into the Deno subprocess environment,

--- a/packages/mcp-server/src/options.ts
+++ b/packages/mcp-server/src/options.ts
@@ -108,7 +108,7 @@ export function parseCLIOptions(): CLIOptions {
       description: 'What transport to use; stdio for local servers or http for remote servers',
     })
     .env('MCP_SERVER')
-    .version(true)
+    .version()
     .help();
 
   const argv = opts.parseSync();


### PR DESCRIPTION
Fixes beeper/desktop-api-js#42

## Root cause

The `execute` tool runs model-supplied code in a Deno subprocess via `@valtown/deno-http-worker`. That library opens its control channel with `Deno.serve({ path: <socket under $TMPDIR> })`. Since Deno 2.9, binding a Unix socket requires **net** access on top of read/write access — and the library appends only `--allow-read=<sock>` / `--allow-write=<sock>` to the caller's `runFlags`, never `--allow-net`. So the subprocess died before it was ready:

```
error: Uncaught (in promise) NotCapable: Requires net access to
"unix:/var/folders/.../T/...-deno-http.sock", run again with the --allow-net flag
    const server = Deno.serve( ...
```

which surfaced to callers as `Deno exited before being ready` on every `execute` call. `search_docs` was unaffected. Consistent with a regression from 5.0.0's `fix(mcp): remove Stainless sandbox execution mode`.

```
  code-tool.ts                    @valtown/deno-http-worker            deno subprocess
  ------------                    -------------------------            ---------------
  runFlags: [                     socketFile = $TMPDIR/<uuid>          Deno.serve({path})
    --allow-read=<pkg>              -deno-http.sock                       |
    --allow-net=<apiHost>    -->  appends --allow-read=<sock>             |
    --allow-env                   appends --allow-write=<sock>            v
  ]                               (never appends --allow-net)      NotCapable: requires
       ^                                    |                      net access to unix:...
       |                                    v
       +-- caller can't name the      spawn(deno, args)  <--- FIX: spawnFunc hook
           socket: path is internal        argv                 rewrites this argv
```

## The fix

The socket path is generated *inside* the library (`path.join(os.tmpdir(), \`${crypto.randomUUID()}-deno-http.sock\`)`) and is never exposed to callers — there is no option or getter for it, in 0.0.21 or in any later version. So the grant is applied through `spawnFunc`, a documented public option in `DenoWorkerOptions`: recover the socket path from the argv the library just built (the only bare, non-flag argument ending in the socket suffix) and append `unix:<path>` to the existing `--allow-net` allowlist.

Building the flag from the argv rather than guessing guarantees it always names the socket actually being served.

**The sandbox is otherwise untouched.** No `-A` / `--allow-all`, no other permission widened. Verified against Deno 2.9.4 that the allowlist matches a Unix socket by **full path only** — `--allow-net=unix:<dir>` is rejected — so this is as tightly as the permission can be scoped, and the fallback to a bare `--allow-net` was not needed.

## Verification

Tested against **Deno 2.9.4** (`deno 2.9.4 (stable, release, x86_64-unknown-linux-gnu)`).

**Standalone repro** — `Deno.serve({ path })` under `--allow-read --allow-write` throws the exact `NotCapable` above; adding `--allow-net=unix:<path>` binds successfully.

**End to end through the real `execute` handler** (stub client, no Beeper Client API needed):

| | before | after |
|---|---|---|
| `return 1 + 1` | `NotCapable ... unix:/tmp/<uuid>-deno-http.sock` → `Deno exited before being ready` | returns `"2"`, `console.log` output captured |
| `fetch("https://example.com")` | — | still blocked: `NotCapable: Requires net access to "example.com:443"` |

That last row is the important one: arbitrary outbound network from sandboxed code remains blocked. Only the API base-URL host and the one control socket are reachable.

I could not exercise this against a running Beeper Client API, so the evidence is the standalone repro plus the end-to-end handler run above.

**Checks** — full suite per CONTRIBUTING, all green:

- Root `yarn lint` — `prettier --check .`, `eslint .`, build, `tsc`, Are The Types Wrong?, publint.
- Root `yarn test` against the `./scripts/mock` steady server — 448 tests / 18 suites pass.
- `packages/mcp-server` — `yarn lint`, `tsc --noEmit`, `jest` (2/2 pass).

No version bumps or CHANGELOG edits: release-please owns those, and it treats `packages/mcp-server/{package.json,manifest.json,yarn.lock}` as version-bump targets. Both commits use conventional-commit `fix(...)` titles so they land under "Bug Fixes" in the generated changelog.

## Note for maintainers: this patches generated code

`packages/mcp-server/src/code-tool.ts` and `src/options.ts` both carry the Stainless `File generated from our OpenAPI spec` header, and `packages/mcp-server` has no `src/lib/` escape hatch — only the root SDK package does. `spawnFunc` is the only seam that can reach the argv, so there is no hand-editable override to use instead.

CONTRIBUTING states modifications to generated code *are* persisted across regenerations (with possible merge conflicts) rather than silently reverted, and the preceding commit `1c50f9f` already patches this same file directly — so I landed it in place. **Please route it through the generator config if that's the house preference.** My read is that it's better kept here: it's a workaround for a Deno-runtime behavior change, ideally temporary, and the real long-term home is upstream in `@valtown/deno-http-worker`, which owns both the socket path and the existing "extend the caller's permission flags" logic. Keeping the patch visible in the generated file means the next regeneration conflict forces someone to re-read it.

Worth filing upstream at val.town separately; note that `^0.0.21` pins exactly for a `0.0.x` range, so absorbing any upstream fix needs a deliberate bump regardless.

## Minor aside (separate commit)

`npx @beeper/desktop-mcp --version` printed `true`. yargs treats a single argument to `.version()` as the version *string*, so `.version(true)` printed `true`. Changed to `.version()`, which reads the version from `package.json` — now prints `5.0.0`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7CWSE6BSsshnh7rZNgomB